### PR TITLE
Added -b=N and -beacon=N

### DIFF
--- a/FactorioPumpjackBlueprint/Program.cs
+++ b/FactorioPumpjackBlueprint/Program.cs
@@ -642,8 +642,14 @@ namespace FactorioPumpjackBlueprint
                     useSpeed3 = true;
                 }
                 else if (Regex.IsMatch(arg, "-b(eacon)?"))
-                {
-                    minPumpjacksPerBeacon = 2;
+                {                    
+                    if (arg.Contains("="))
+                        minPumpjacksPerBeacon = int.Parse(arg.Substring(arg.IndexOf('=') + 1));
+                        if (minPumpjacksPerBeacon < 1)
+                            minPumpjacksPerBeacon = 1;
+                    else
+                        minPumpjacksPerBeacon = 2;
+                    useSpeed3 = true;
                     useSpeed3 = true;
                 }
                 else if (Regex.IsMatch(arg, "-i=\\d+"))


### PR DESCRIPTION
Initially a beacon needed to hit at least 2 pumpjacks to be placed. Now you can specify how many need to be hit to be placed. If -b or -beacon is used then it defaults to the original 2.